### PR TITLE
Replace deprecated methods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 torches = {}
-torches.enable_ceiling = minetest.setting_getbool("torches_enable_ceiling") or false
-local style = minetest.setting_get("torches_style")
+torches.enable_ceiling = minetest.settings:get_bool("torches_enable_ceiling") or false
+local style = minetest.settings:get("torches_style")
 
 local modpath = minetest.get_modpath("torches")
 


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267